### PR TITLE
fix: resolve EntityFrameworkCore version conflict

### DIFF
--- a/PersonalWeb.MigrationService/PersonalWeb.MigrationService.csproj
+++ b/PersonalWeb.MigrationService/PersonalWeb.MigrationService.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.3.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
   </ItemGroup>
 


### PR DESCRIPTION
Update Microsoft.EntityFrameworkCore from 10.0.1 to 10.0.8 in PersonalWeb.MigrationService to match the version required by PersonalWeb.Api. This resolves the NuGet package downgrade error that was causing the build to fail.